### PR TITLE
Fix black action arguments + formatting

### DIFF
--- a/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          args: ". --check"
+          options: "--check"
+          src: "."
       - name: docstrings
         run: |
           pip install flit

--- a/{{cookiecutter.github_project_name}}/docs/conf.py
+++ b/{{cookiecutter.github_project_name}}/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath('../{{ cookiecutter.python_package_name }}'))
 
 
@@ -37,7 +38,7 @@ extensions = [
     "numpydoc",
     'sphinx.ext.autodoc',
     'sphinx.ext.inheritance_diagram',
-    'autoapi.sphinx'
+    'autoapi.sphinx',
 ]
 
 sphinx_gallery_conf = {

--- a/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/__init__.py
+++ b/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/__init__.py
@@ -4,9 +4,8 @@
 # Copyright (c) {{ cookiecutter.author_name }}.
 # Distributed under the terms of the Modified BSD License.
 
-# Must import __version__ first to avoid errors importing this file during the build process. 
+# Must import __version__ first to avoid errors importing this file during the build process.
 # See https://github.com/pypa/setuptools/issues/1724#issuecomment-627241822
 from ._version import __version__
 
 from .example import example_function
-

--- a/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/example.py
+++ b/{{cookiecutter.github_project_name}}/{{cookiecutter.python_package_name}}/example.py
@@ -25,7 +25,7 @@ def example_function(ax, data, above_color="r", below_color="k", **kwargs):
         The color of points with `y>0`
     below_color : color-like, default: 'k'
         The color of points with `y<0`
-    kwargs :
+    **kwargs
         Passed through to `ax.scatter`
 
     Returns


### PR DESCRIPTION
Seems like black has changed the argument handling. I got this on my newly create repo:

```
Warning: Unexpected input(s) 'args', valid inputs are ['options', 'src', 'black_args', 'version']
```

https://black.readthedocs.io/en/stable/integrations/github_actions.html gives the changes in this PR. `src` is not really required since `.` is the default, but I included it for clarity in case someone want to change it later.

The second commit fixes two issues that black points out in the generated code.

Edit: third commit fixes doc formatting.

Let me know if I should squash these into a single commit. Updating as I go along making my project pass the tests with the default setup.