### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: codespell-project/actions-codespell@master
+      - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           check_filenames: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
         with:
           check_filenames: true

--- a/{{cookiecutter.github_project_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.github_project_name}}/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:

--- a/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:

--- a/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@v2
-      - uses: psf/black@stable
+      - uses: psf/black@8a737e727ac5ab2f1d4cf5876720ed276dc8dc4b # 25.1.0
         with:
           options: "--check"
           src: "."

--- a/{{cookiecutter.github_project_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     steps:
     - uses: actions/checkout@v2
       with:

--- a/{{cookiecutter.github_project_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Install Python
       uses: actions/setup-python@v2
       with:

--- a/{{cookiecutter.github_project_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
 # heavily based on https://github.com/jupyterlab/jupyterlab-git/blob/v0.22.2/.github/workflows/publish.yml
 name: Publish Package
+permissions:
+  contents: read
 
 on:
   release:

--- a/{{cookiecutter.github_project_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:

--- a/{{cookiecutter.github_project_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.github_project_name}}/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
         
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/{{cookiecutter.github_project_name}}/.gitignore
+++ b/{{cookiecutter.github_project_name}}/.gitignore
@@ -151,5 +151,16 @@ cython_debug/
 [._]sw[a-p]
 [._]*.un~
 
-## vscode
-.vscode
+
+## Editor temporary/working/backup files #
+.#*
+[#]*#
+*~
+*$
+*.bak
+*.kdev4
+.project
+.pydevproject
+*.swp
+.idea
+.vscode/


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
